### PR TITLE
A bunch of fixes

### DIFF
--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -181,7 +181,7 @@
 
 ;;; LS protocol handling.
 
-(defstruct ls-connection
+(cl-defstruct lsp-connection
   process
   session
   bufname
@@ -234,7 +234,7 @@
                   (search-forward "\r\n{")
                   (let* ((content-body (buffer-substring (- (point) 1) (+ (- (point) 1) content-length)))
                          (content (let ((json-array-type 'list)) (json-read-from-string content-body)))
-                         (sess (ls-connection-session conn))
+                         (sess (lsp-connection-session conn))
                          (id (alist-get 'id content))
                          (cb (gethash id sess)))
                     ;; remove the request from the buffer
@@ -264,7 +264,7 @@
                            (lsp-display-err-and-wait-for-confirmation body)
                            (init-lsp-conn-inner ws conn)))
                         ((equal res :success)
-                         (setf (ls-connection-server-caps conn) (alist-get 'capabilities body)))))))
+                         (setf (lsp-connection-server-caps conn) (alist-get 'capabilities body)))))))
 
 (defun lsp-mode-init-conn (host port)
   "Initialize a new connection to an LSP"
@@ -273,7 +273,7 @@
          (net-proc (open-network-stream "lsp" bufname host port :type 'plain ))
          (session (make-hash-table))
          (ws (projectile-project-root))
-         (conn (make-ls-connection :process net-proc :session session :bufname bufname))
+         (conn (make-lsp-connection :process net-proc :session session :bufname bufname))
          )
     (set-process-filter net-proc (lsp-filter session))
     (puthash ws conn lsp-ws-connection-map)
@@ -286,8 +286,8 @@
 (defun send-lsp-msg (req &optional cb)
   (let ((s (gethash ws-cache lsp-ws-connection-map))
         (nid (abs (random (- (expt 2 64) 1)))))
-    (puthash nid cb (ls-connection-session s))
-    (process-send-string (ls-connection-process s) (lsp-message (cons `(id . ,nid) req)))
+    (puthash nid cb (lsp-connection-session s))
+    (process-send-string (lsp-connection-process s) (lsp-message (cons `(id . ,nid) req)))
     )
   )
 

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -18,7 +18,7 @@
 (defun lsp-wrap-payload (body &optional content-type)
   "Add Content-Type and Content-Length headers to an LSP payload"
   (let ((len (length body))
-        (type (if (null content-type) "application/vscode-jsonrpc; charset=utf-8" type)))
+        (type (or content-type "application/vscode-jsonrpc; charset=utf-8")))
     (apply 'concat (mapcar (lambda (s) (encode-coding-string s 'utf-8))
                             `("Content-Length: " ,(number-to-string len) "\r\n" "Content-Type: " ,type "\r\n\r\n" ,body)))
     )

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -229,7 +229,7 @@
                 (goto-char 17)
                 (looking-at "[0-9]+")
                 (let ((content-length (string-to-int (match-string 0)))
-                      (conn (gethash ws-cache lsp-ws-connection-map)))
+                      (conn (gethash lsp-ws-cache lsp-ws-connection-map)))
                   ;; scan point forward to start of body
                   (search-forward "\r\n{")
                   (let* ((content-body (buffer-substring (- (point) 1) (+ (- (point) 1) content-length)))
@@ -281,10 +281,10 @@
     (send-lsp-msg (lsp-did-open-text-doc (lsp-text-doc-id (uri-for-path (buffer-file-name)))) 'lsp-ignore)
     ))
 
-(defvar-local ws-cache (projectile-project-root))
+(defvar-local lsp-ws-cache (projectile-project-root))
 
 (defun send-lsp-msg (req &optional cb)
-  (let ((s (gethash ws-cache lsp-ws-connection-map))
+  (let ((s (gethash lsp-ws-cache lsp-ws-connection-map))
         (nid (abs (random (- (expt 2 64) 1)))))
     (puthash nid cb (lsp-connection-session s))
     (process-send-string (lsp-connection-process s) (lsp-message (cons `(id . ,nid) req)))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -4,7 +4,7 @@
 
 ;; Author: Corey Richardson <corey@octayn.net>
 ;; Keywords: convenience
-;; Package-Requires: ((projectile "0.14.0"))
+;; Package-Requires: ((projectile "0.14.0") (emacs "25.1"))
 
 ;;; Code:
 

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -322,7 +322,7 @@ BODY is the payload, and CONTENT-TYPE is a non-default content type."
   nil)
 
 (defun lsp-current-lsp-pos ()
-  (lsp-position (line-number-at-pos (point)) (current-column)))
+  (lsp-position (1- (line-number-at-pos (point))) (current-column)))
 
 (defun lsp-current-lsp-text-doc-pos ()
   (lsp-text-doc-pos-params (lsp-buffer-text-doc-id) (lsp-current-lsp-pos)))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -278,7 +278,7 @@
     (set-process-filter net-proc (lsp-filter session))
     (puthash ws conn lsp-ws-connection-map)
     (init-lsp-conn-inner ws conn)
-    (send-lsp-msg (lsp-did-open-text-doc (lsp-text-doc-id (uri-for-path (buffer-file-name)))) 'lsp-ignore)
+    (send-lsp-msg (lsp-did-open-text-doc (lsp-buffer-text-doc-id)) 'lsp-ignore)
     ))
 
 (defvar-local lsp-ws-cache (projectile-project-root))
@@ -294,18 +294,22 @@
 (defun uri-for-path (p)
   (concat "file://" p)) ; FIXME: more robust? does this work on windows?
 
+(defun lsp-buffer-text-doc-id (&optional buffer)
+  "Return the text doc ID for BUFFER, or the current buffer if not supplied."
+  (lsp-text-doc-id (uri-for-path (buffer-file-name buffer))))
+
 (defun lsp-mode-find-file-hook ()
-  (send-lsp-msg (lsp-did-open-text-doc (lsp-text-doc-id (uri-for-path (buffer-file-name)))) 'lsp-ignore))
+  (send-lsp-msg (lsp-did-open-text-doc (lsp-buffer-text-doc-id)) 'lsp-ignore))
 
 (defun lsp-mode-write-file-functions ()
-  (send-lsp-msg (lsp-did-save-text-doc (lsp-text-doc-id (uri-for-path (buffer-file-name)))) 'lsp-ignore)
+  (send-lsp-msg (lsp-did-save-text-doc (lsp-buffer-text-doc-id)) 'lsp-ignore)
   nil)
 
 (defun current-lsp-pos ()
   (lsp-position (line-number-at-pos (point)) (current-column)))
 
 (defun current-lsp-text-doc-pos ()
-  (lsp-text-doc-pos-params (lsp-text-doc-id (uri-for-path (buffer-file-name))) (current-lsp-pos)))
+  (lsp-text-doc-pos-params (lsp-buffer-text-doc-id) (current-lsp-pos)))
 
 (defun alist-navigate (obj &rest path)
   "Extract a property from an alist, using successive symbols from path."

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -19,10 +19,9 @@
   "Add Content-Type and Content-Length headers to an LSP payload"
   (let ((len (length body))
         (type (or content-type "application/vscode-jsonrpc; charset=utf-8")))
-    (apply 'concat (mapcar (lambda (s) (encode-coding-string s 'utf-8))
-                            `("Content-Length: " ,(number-to-string len) "\r\n" "Content-Type: " ,type "\r\n\r\n" ,body)))
-    )
-  )
+    (mapconcat (lambda (s) (encode-coding-string s 'utf-8))
+               `("Content-Length: " ,(number-to-string len) "\r\n" "Content-Type: " ,type "\r\n\r\n" ,body)
+               "")))
 
 (defun lsp-message (msg)
   (lsp-wrap-payload (json-encode msg)))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -329,9 +329,9 @@ BODY is the payload, and CONTENT-TYPE is a non-default content type."
 
 (defun lsp-alist-navigate (obj &rest path)
   "Extract a property from an alist, using successive symbols from path."
-  (let ((cur_obj obj))
-    (dolist (cur path cur_obj)
-      (setq cur_obj (alist-get cur cur_obj)))))
+  (let ((cur-obj obj))
+    (dolist (cur path cur-obj)
+      (setq cur-obj (alist-get cur cur-obj)))))
 
 (defun lsp-mode-goto-loc (loc)
   (let ((comps (split-string (alist-get 'uri loc) "://")))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -434,6 +434,7 @@ BODY is the payload, and CONTENT-TYPE is a non-default content type."
   (interactive)
   (lsp-send-msg (lsp-shutdown) 'lsp-ignore))
 
+;;;###autoload
 (define-minor-mode lsp-mode
   "Use a Language Server to provide semantic information about your code."
   :lighter " lsp"

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -6,6 +6,17 @@
 ;; Keywords: convenience
 ;; Package-Requires: ((projectile "0.14.0") (emacs "25.1"))
 
+;;; Commentary:
+
+;; Activating `lsp-mode' in a buffer enables LSP server communication
+;; support.  Use `lsp-mode-init-conn' to initialize a connection to an
+;; LSP server.  Only connections over TCP are supported right now.
+;; Each LSP connection is associated with a `projectile-project-root':
+;; lsp-mode will try to use the connection for the project
+;; corresponding to the current buffer.
+
+;; See `lsp-mode-map' for further commands.
+
 ;;; Code:
 
 (require 'projectile)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -292,8 +292,7 @@
   )
 
 (defun uri-for-path (p)
-  (apply 'concat (list "file://" p)) ; FIXME: more robust? does this work on windows?
-  )
+  (concat "file://" p)) ; FIXME: more robust? does this work on windows?
 
 (defun lsp-mode-find-file-hook ()
   (send-lsp-msg (lsp-did-open-text-doc (lsp-text-doc-id (uri-for-path (buffer-file-name)))) 'lsp-ignore))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -229,7 +229,7 @@
                 (goto-char 17)
                 (looking-at "[0-9]+")
                 (let ((content-length (string-to-int (match-string 0)))
-                      (conn (gethash lsp-ws-cache lsp-ws-connection-map)))
+                      (conn (gethash (lsp-ws-cache-key) lsp-ws-connection-map)))
                   ;; scan point forward to start of body
                   (search-forward "\r\n{")
                   (let* ((content-body (buffer-substring (- (point) 1) (+ (- (point) 1) content-length)))
@@ -281,10 +281,11 @@
     (lsp-send-msg (lsp-did-open-text-doc (lsp-buffer-text-doc-id)) 'lsp-ignore)
     ))
 
-(defvar-local lsp-ws-cache (projectile-project-root))
+(defun lsp-ws-cache-key ()
+  (projectile-project-root))
 
 (defun lsp-send-msg (req &optional cb)
-  (let ((s (gethash lsp-ws-cache lsp-ws-connection-map))
+  (let ((s (gethash (lsp-ws-cache-key) lsp-ws-connection-map))
         (nid (abs (random (- (expt 2 64) 1)))))
     (puthash nid cb (lsp-connection-session s))
     (process-send-string (lsp-connection-process s) (lsp-message (cons `(id . ,nid) req)))

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -1,4 +1,4 @@
-;;; lsp-mode.el --- Support for talking to an LSP server to provide semantic information about programs
+;;; lsp-mode.el --- Use a Language Server to provide semantic information about your code
 
 ;; Copyright (c) 2016 Sourcegraph Inc
 

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -282,7 +282,7 @@ BODY is the payload, and CONTENT-TYPE is a non-default content type."
                      (setf (lsp-connection-server-caps conn) (alist-get 'capabilities body)))))))
 
 (defun lsp-mode-init-conn (host port)
-  "Initialize a new connection to an LSP"
+  "Initialize a new connection to an LSP on HOST and PORT."
   (interactive "Mhostname:\nnport:")
   (let* ((bufname (concat "*lsp*" (int-to-string (random))))
          (net-proc (open-network-stream "lsp" bufname host port :type 'plain ))
@@ -328,7 +328,7 @@ BODY is the payload, and CONTENT-TYPE is a non-default content type."
   (lsp-text-doc-pos-params (lsp-buffer-text-doc-id) (lsp-current-lsp-pos)))
 
 (defun lsp-alist-navigate (obj &rest path)
-  "Extract a property from an alist, using successive symbols from path."
+  "Extract a property from an alist OBJ, using successive symbols from PATH."
   (let ((cur-obj obj))
     (dolist (cur path cur-obj)
       (setq cur-obj (alist-get cur cur-obj)))))
@@ -345,7 +345,7 @@ BODY is the payload, and CONTENT-TYPE is a non-default content type."
       )))
 
 (defun lsp-mode-select-destination (locs)
-  "Given a list of locations, display them in a new window with hyperlinks"
+  "Given a list of locations LOCS, display them in a new window with hyperlinks."
   (let ((buf (get-buffer-create "*LSP-Select-Destination*")))
     (with-current-buffer buf
       (erase-buffer)
@@ -358,7 +358,7 @@ BODY is the payload, and CONTENT-TYPE is a non-default content type."
     (switch-to-buffer-other-window buf)))
 
 (defun lsp-mode-list-symbols (syms)
-  "Given a list of symbols, display them in a new window with hyperlinks"
+  "Given a list of symbols SYMS, display them in a new window with hyperlinks."
   (let ((buf (get-buffer-create "*LSP-List-Symbols*")))
     (with-current-buffer buf
       (erase-buffer)
@@ -387,7 +387,7 @@ BODY is the payload, and CONTENT-TYPE is a non-default content type."
                 (lsp-mode-select-destination body)))))
 
 (defun lsp-mode-goto ()
-  "Go to the definition of the symbol near point"
+  "Go to the definition of the symbol near point."
   (interactive)
   (lsp-send-msg (lsp-goto-def (lsp-current-lsp-text-doc-pos)) 'lsp-mode-goto-cb))
 
@@ -403,7 +403,7 @@ BODY is the payload, and CONTENT-TYPE is a non-default content type."
        (display-message-or-buffer (apply 'concat message) "*LSP-Hover*")))))
 
 (defun lsp-mode-hover ()
-  "Display hover information for the symbol near point"
+  "Display hover information for the symbol near point."
   (interactive)
   (lsp-send-msg (lsp-hover (lsp-current-lsp-text-doc-pos)) 'lsp-mode-hover-cb))
 
@@ -413,7 +413,7 @@ BODY is the payload, and CONTENT-TYPE is a non-default content type."
     (:success (lsp-mode-select-destination (if (alist-get 'uri body) (list body) body)))))
 
 (defun lsp-mode-references ()
-  "Find references to the symbol near point"
+  "Find references to the symbol near point."
   (interactive)
   (lsp-send-msg (lsp-find-refs (lsp-ref-params (lsp-current-lsp-text-doc-pos)
                                                (lsp-ref-context json-false)))
@@ -425,16 +425,17 @@ BODY is the payload, and CONTENT-TYPE is a non-default content type."
     (:success (lsp-mode-list-symbols body))))
 
 (defun lsp-mode-symbol (query)
-  "Search for project-wide symbols matching the query string"
+  "Search for project-wide symbols matching the QUERY string."
   (interactive "Mquery:")
   (lsp-send-msg (lsp-workspace-symbols (lsp-workspace-symbol-params query)) 'lsp-mode-symbol-cb))
 
 (defun lsp-mode-shutdown ()
+  "Tell the language server to shut down."
   (interactive)
   (lsp-send-msg (lsp-shutdown) 'lsp-ignore))
 
 (define-minor-mode lsp-mode
-  "Use a Language Server to provide semantic information about your code"
+  "Use a Language Server to provide semantic information about your code."
   :lighter " lsp"
   :keymap (let ((map (make-sparse-keymap)))
             (define-key map (kbd "C-c C-l i") 'lsp-mode-init-conn)

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -455,3 +455,4 @@ BODY is the payload, and CONTENT-TYPE is a non-default content type."
   )
 
 (provide 'lsp-mode)
+;;; lsp-mode.el ends here

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -27,12 +27,15 @@
 ;;; LSP datatype construction
 
 (defun lsp-wrap-payload (body &optional content-type)
-  "Add Content-Type and Content-Length headers to an LSP payload"
-  (let ((len (length body))
-        (type (or content-type "application/vscode-jsonrpc; charset=utf-8")))
-    (mapconcat (lambda (s) (encode-coding-string s 'utf-8))
-               `("Content-Length: " ,(number-to-string len) "\r\n" "Content-Type: " ,type "\r\n\r\n" ,body)
-               "")))
+  "Add Content-Type and Content-Length headers to an LSP payload.
+BODY is the payload, and CONTENT-TYPE is a non-default content type."
+  (let ((encoded-body (if content-type
+                          body
+                        (encode-coding-string body 'utf-8))))
+    (format "Content-Length: %d\r\nContent-Type: %s\r\n\r\n%s"
+            (length encoded-body)
+            (or content-type "application/vscode-jsonrpc; charset=utf-8")
+            encoded-body)))
 
 (defun lsp-message (msg)
   (lsp-wrap-payload (json-encode msg)))


### PR DESCRIPTION
Hi! I came across langserver recently, and looked at this code in relation to it. I administer MELPA, and we've got a different version of lsp-mode packaged there right now. I'd like to replace it with this version, and noticed a few details in the code which would benefit from being cleaned up. This PR includes a number of small fixes to that end: they should all be safe, but please double-check, because I haven't had the opportunity to regression test them against the old code.

When merged, I'll see about pointing MELPA's lsp-mode recipe at this repo instead of the other one.

Cheers!